### PR TITLE
Fix/fetch all branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
           branches_to_merge_automatically: "/*-wip,develop,master"
           commit_message_template: '[Automated] Merged {source_ref} into target {target_branch}'
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
-          slack_webhook_tag_user_id: "<@U3P5KJ6SH><@U0MD57CMC><@UAQ9TESKU>"
+          slack_webhook_tag_user_id: "<@SLACK_MEMBER_ID><@SLACK_MEMBER_ID><@SLACK_MEMBER_ID>"
 ```
 
 
@@ -63,4 +63,4 @@ for example: "develop,main,master"
 **Optional** - Customize the commit message that gets added to the merge commit.
 
 ### `slack_webhook_tag_user_id`
-**Optional** - Id of one or more slack users you want to tag in the message, for example: "<@U3P5KJ6SH><@U0MD57CMC><@UAQ9TESKU>"
+**Optional** - Member Id of one or more slack users you want to tag in the message, for example: "<@H1H1HH1HH><@H1H1HH1HH><@H1H1HH1HH>"

--- a/src/action.js
+++ b/src/action.js
@@ -5,6 +5,9 @@ const core = require("@actions/core");
 async function run() {
   let branchesError = "";
   let branchesSuccess = "";
+  const branches = [];
+  let branches_page = 1;
+  const branches_per_page = 100;// Max of branches per page allowed.
   try {
     const token = core.getInput("github_token");
     const source_ref = core.getInput("source_ref");
@@ -13,16 +16,20 @@ async function run() {
       "branches_to_merge_automatically"
     );
     const octokit = github.getOctokit(token);
-
     const repo = github.context.repo;
     const formatBranch = branchesAutomatically.split(",");
 
-    const { data } = await octokit.rest.repos.listBranches({
-      owner: repo.owner,
-      repo: repo.repo,
-    });
+    let branchesBatch = await getBranchesBatch(repo, octokit, branches_page, branches_per_page);
+    while (branchesBatch.length === branches_per_page) {
+      branches.push.apply(branches, branchesBatch);
+      branches_page++;
+      branchesBatch = await getBranchesBatch(repo, octokit, branches_page, branches_per_page);
+    }
+    branches.push.apply(branches, branchesBatch);
 
-    for (const currentBranch of data) {
+    core.info(`Branches total size ${branches.length}.`);
+
+    for (const currentBranch of branches) {
       for (const element of formatBranch) {
         if (new RegExp(element).test(currentBranch.name)) {
           let commitMessage = commit_message_template
@@ -47,6 +54,21 @@ async function run() {
     sendNotificationSlack(branchesSuccess, branchesError);
   } catch (e) {
     core.setFailed(`Error Merge: ${e.message}`);
+  }
+}
+
+async function getBranchesBatch(repo, octokit, branches_page, branches_per_page) {
+  try {
+    const { data } = await octokit.rest.repos.listBranches({
+      owner: repo.owner,
+      repo: repo.repo,
+      per_page: branches_per_page,
+      page: branches_page,
+    });
+    if (Array.isArray(data)) return data;
+    return [];
+  } catch (error) {
+    core.setFailed(`Error Slack: ${error.message}`);
   }
 }
 


### PR DESCRIPTION
Issue: Currently auto merge will fetch approx only 20 branches to auto merge.
Fixes: 
- Retrieve 100 branches per page.
- Iterate under the condition of: if currentBranchesList length is equal to 100, then request a next page until we reached the last page with length minor than 100.